### PR TITLE
(Fix) init 'ret' variable in mem_bank_get() API

### DIFF
--- a/lis2dux12_reg.c
+++ b/lis2dux12_reg.c
@@ -1205,7 +1205,7 @@ exit:
 int32_t lis2dux12_mem_bank_get(const stmdev_ctx_t *ctx, lis2dux12_mem_bank_t *val)
 {
   lis2dux12_func_cfg_access_t func_cfg_access;
-  int32_t ret;
+  int32_t ret = 0;
 
   if (ctx->priv_data == NULL)
   {


### PR DESCRIPTION
Fix an issue that has been reported by zephyr using clang compiler

To reproduce in zephyr:

```
export ZEPHYR_TOOLCHAIN_VARIANT=llvm
west build -p -b native_sim/native tests/drivers/build_all/sensor -T drivers.sensor.trigger.own.build

/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c:1219:7: warning: variable 'ret' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
 1219 |   if (func_cfg_access.emb_func_reg_access == 0)
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c:1248:10: note: uninitialized use occurs here
 1248 |   return ret;
      |          ^~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c:1219:3: note: remove the 'if' if its condition is always true
 1219 |   if (func_cfg_access.emb_func_reg_access == 0)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1220 |   {
/local/home/visconti/Projects/GIT/FW/zephyrproject/modules/hal/st/sensor/stmemsc/lis2dux12_STdC/driver/lis2dux12_reg.c:1208:14: note: initialize the variable 'ret' to silence this warning
 1208 |   int32_t ret;
      |              ^
      |               = 0
1 warning generated.

```